### PR TITLE
Fix: grid styles

### DIFF
--- a/app/scripts/components/Article/article-template.html
+++ b/app/scripts/components/Article/article-template.html
@@ -1,9 +1,13 @@
 <article class="c-article">
-  <div :class="gridRow">
 
-    <div :class="gridColumn">
+  <div v-if="gridRow" :class="gridRow">
+    <div v-if="gridColumn" :class="gridColumn">
       <slot></slot>
     </div>
 
+    <slot v-else></slot>
   </div>
+
+  <slot v-else></slot>
+
 </article>

--- a/app/scripts/components/Article/index.vue
+++ b/app/scripts/components/Article/index.vue
@@ -5,11 +5,11 @@ export default{
   name: 'article-component',
   props: {
     gridRow: {
-      type: [String, Array],
+      type: [String, Boolean],
       default: 'row align-center',
     },
     gridColumn: {
-      type: [String, Array],
+      type: [String, Boolean],
       default: 'columns small-12 medium-10',
     },
   },

--- a/app/scripts/components/Footer/footer-template.html
+++ b/app/scripts/components/Footer/footer-template.html
@@ -1,9 +1,9 @@
 <div class="c-footer">
-  <div class="row">
-    <div class="columns small-6 medium-2">
+  <div class="row align-justify">
+    <div class="columns small-6 medium-3">
       <img :src="logoGlobalSDD" class="footer-logo">
     </div>
-    <div class="columns small-6 medium-2 medium-offset-8">
+    <div class="columns small-5 medium-3 medium-offset-5 large-2 large-offset-7">
       <img :src="logoVizz" class="footer-logo">
     </div>
   </div>

--- a/app/scripts/components/Header/header-template.html
+++ b/app/scripts/components/Header/header-template.html
@@ -1,12 +1,12 @@
 <div class="c-header">
-  <div class="row align-top">
-    <div class="columns small-6 medium-2">
+  <div class="row align-top align-justify">
+    <div class="columns small-4 medium-2 medium-offset-1">
       <router-link to="/" class="header-logo">
         <img :src="d4sdgLogo">
       </router-link>
     </div>
 
-    <div class="columns small-6 medium-3 medium-offset-7">
+    <div class="columns small-6 medium-3 medium-offset-6">
       <nav>
         <ul>
           <li :class="firstTabClass">

--- a/app/scripts/components/Hero/hero-style.scss
+++ b/app/scripts/components/Hero/hero-style.scss
@@ -18,8 +18,5 @@
 
   .hero-app-content {
     padding: ($medium-margin * 3) 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
   }
 }

--- a/app/scripts/components/Hero/hero-template.html
+++ b/app/scripts/components/Hero/hero-template.html
@@ -1,7 +1,7 @@
 <div :class="styles">
 
   <div class="row" v-if="location.home">
-    <div class="column small-11 medium-10 small-offset-1 medium-offset-2 large-offset-0 hero-home-content">
+    <div class="column small-11 medium-6 small-offset-1 medium-offset-1 hero-home-content">
       <h2>Transform data on SDGs into effective applications</h2>
       <div class="c-button-group">
         <button-component class="-bordered -big" :click="goToFindOutMore">Find Out More</button-component>
@@ -9,8 +9,8 @@
     </div>
   </div>
 
-  <div class="row align-center">
-    <div class="column small-10 hero-app-content" v-if="!location.home">
+  <div class="row">
+    <div class="column small-12 medium-10 hero-app-content" v-if="!location.home">
       <search-component></search-component>
     </div>
   </div>

--- a/app/scripts/components/Home/home-style.scss
+++ b/app/scripts/components/Home/home-style.scss
@@ -45,12 +45,15 @@
   }
 
   .link-column {
-    height: 50%;
-    width: 70%;
+    height: 30%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    > .link-column-action {
+    align-items: flex-start;
+    padding-left: $medium-margin * 2;
+
+    .link-column-action {
       color: $theme-accent;
 
       &:after {
@@ -66,6 +69,10 @@
         border-right: 2px solid $theme-accent;
 
       }
+    }
+
+    @media (min-width: 640px) and (max-width: 726px) {
+      height: 60%;
     }
   }
 

--- a/app/scripts/components/Home/home-template.html
+++ b/app/scripts/components/Home/home-template.html
@@ -1,9 +1,9 @@
 <div class="c-home">
   <article-component class="about-us">
     <h1>Data4SDGs Developer Playground</h1>
-    <h4>DATA4SDGS GOALS</h4>
+    <h4 class="-center">DATA4SDGS GOALS</h4>
 
-    <div class="row">
+    <div class="row expanded">
       <div class="column small-12 medium-6 large-4 info-column">
         <icon-component class="-round -small -base" name="icon-data"></icon-component>
         <div class="info-column-text">
@@ -50,32 +50,34 @@
     </div>
   </article-component>
 
-  <article-component class="-alternative -no-padding" grid-row="row expanded" grid-column="small-12">
-    <div class="row expanded">
+  <article-component class="-alternative -no-padding" grid-row="row expanded" :grid-column="false">
 
       <div class="column small-12 medium-6 split-view">
-        <div class="link-column">
-          <h1 class="-clean -left">Playbook</h1>
-          <p class="-clean">
-            Learn how to turn your SDG data into data services and
-            make it available to millions of software developers.
-          </p>
-          <a class="link-column-action">Read Playbook</a>
+        <div class="link-column row">
+          <div class="column small-10 large-7 large-offset-1">
+            <h1 class="-clean -left">Playbook</h1>
+            <p class="-clean">
+              Learn how to turn your SDG data into data services and
+              make it available to millions of software developers.
+            </p>
+            <a class="link-column-action">Read Playbook</a>
+          </div>
         </div>
       </div>
 
       <div class="column small-12 medium-6 split-view">
-        <div class="link-column">
-          <h1 class="-clean -left">shared, open software</h1>
-          <p class="-clean">
-            All software used in the making of the developer playground is open source
-            and available online. Take a look and if you want, contribute!
-          </p>
-          <a class="link-column-action">Source Code</a>
+        <div class="link-column row">
+          <div class="column small-10 large-7">
+            <h1 class="-clean -left">shared, open software</h1>
+            <p class="-clean">
+              All software used in the making of the developer playground is open source
+              and available online. Take a look and if you want, contribute!
+            </p>
+            <a class="link-column-action">Source Code</a>
+          </div>
         </div>
       </div>
 
-    </div>
   </article-component>
 
   <article-component>

--- a/app/scripts/components/Playground/index.vue
+++ b/app/scripts/components/Playground/index.vue
@@ -23,6 +23,9 @@ export default{
     next();
   },
   computed: {
+    storeRouter() {
+      return this.$store.route;
+    },
     ...mapGetters({
       featuredDatasets: 'getFeaturedListData',
       loading: 'getFeaturedLoading',
@@ -40,7 +43,7 @@ export default{
     },
   },
   watch: {
-    router() {
+    storeRouter() {
       if (router.params.dataset) {
         this.$store.dispatch('setSelectedDataset', router.to.params.dataset).then(() => store.dispatch('openConsoleModal'));
       }

--- a/app/scripts/components/Playground/playground-template.html
+++ b/app/scripts/components/Playground/playground-template.html
@@ -1,10 +1,10 @@
 <div class="c-playground">
-  <article-component v-if="recentDatasets.length">
+  <article-component v-if="recentDatasets.length" grid-column="small-10 medium-10 small-offset-2 medium-offset-0">
     <h1 class="-left">Recent Datasets</h1>
     <dataset-list-component :datasets="recentDatasets"></dataset-list-component>
   </article-component>
 
-  <article-component>
+  <article-component grid-column="small-10 medium-10 small-offset-2 medium-offset-0">
     <h1 class="-left">Featured Datasets</h1>
     <dataset-list-component :datasets="featuredDatasets"></dataset-list-component>
     <spinner-component :loading="featuresLoading"></spinner-component>

--- a/app/scripts/components/Search/search-style.scss
+++ b/app/scripts/components/Search/search-style.scss
@@ -8,9 +8,13 @@ $checkbox-color: #87929a;
   align-items: center;
   justify-content: space-around;
 
+  .filters-dropdown {
+    z-index: 1;
+  }
+
   .search-bar {
     height: 60px;
-    width: 600px;
+    width: 100%;
 
     .search-input {
       height: 100%;
@@ -50,6 +54,11 @@ $checkbox-color: #87929a;
         }
       }
     }
+
+    @media (max-width: 639px) {
+      margin-top: $small-margin;
+    }
+
   }
 
   .c-checkbox-group {

--- a/app/scripts/components/Search/search-template.html
+++ b/app/scripts/components/Search/search-template.html
@@ -1,26 +1,25 @@
-<div class="c-search row align-left">
-    <div class="column small-2">
-      <dropdown-component>
-      <checkbox-component :items="filters" icon="icon-check"></checkbox-component>
-      </dropdown-component>
-    </div>
-    <div class="column small-8">
-      <div class="search-bar">
-        <input type="search" v-model.trim="queryState" placeholder="Search for data..." class="search-input">
-        <ul class="search-results-list">
-          <li v-if="loading" class="search-results-item">{{loadingMessage}}</li>
-          <li v-else-if="error" class="search-results-item -error">{{errorMessage}}</li>
-          <li v-else-if="notFound" class="search-results-item">{{notFoundMessage}}</li>
-          <li
-            v-else-if="query"
-            v-for="result in results"
-            class="search-results-item -item"
-            @click="selectDataset(result)">
-            {{result.name}}
-          </li>
-        </ul>
+<div class="c-search row">
+      <div class="column small-10 medium-5 large-3 small-offset-1 filters-dropdown">
+        <dropdown-component>
+          <checkbox-component :items="filters" icon="icon-check"></checkbox-component>
+        </dropdown-component>
       </div>
-    </div>
+      <div class="column small-10 medium-6 large-7 small-offset-1 medium-offset-0 search-bar">
+          <input type="search" v-model.trim="queryState" placeholder="Search for data..."
+                 class="search-input">
+          <ul class="search-results-list">
+            <li v-if="loading" class="search-results-item">{{loadingMessage}}</li>
+            <li v-else-if="error" class="search-results-item -error">{{errorMessage}}</li>
+            <li v-else-if="notFound" class="search-results-item">{{notFoundMessage}}</li>
+            <li
+              v-else-if="query"
+              v-for="result in results"
+              class="search-results-item -item"
+              @click="selectDataset(result)">
+              {{result.name}}
+            </li>
+          </ul>
+      </div>
 </div>
 
 

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -45,4 +45,8 @@ const routes = [
 export default new VueRouter({
   mode: 'history',
   routes,
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) return savedPosition;
+    return { x: 0, y: 0 };
+  },
 });

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "vue-loader": "^9.4.0",
     "vue-router": "^2.0.2",
     "vue-style-loader": "^1.0.0",
-    "vue-swipe": "^2.0.0",
     "vuex": "^2.0.0",
     "vuex-router-sync": "^4.0.1",
     "webpack": "^1.13.2",


### PR DESCRIPTION
This PR includes the following:
- Changes the watcher on the playground vue to watch changes on the store instead of watching them on the router component, mainly for consistency.
- Removes unused library vue-swipe.
- Fixes wrong grid classes on several components (Header, Hero, Home, Search, Playground & Footer)
- Adds router scroll behaviour, in order to start a new route on the top of the page.